### PR TITLE
Add Docker-based Kafka topic creator

### DIFF
--- a/KafkaTopic.Dockerfile
+++ b/KafkaTopic.Dockerfile
@@ -1,0 +1,4 @@
+FROM bitnami/kafka:latest
+COPY docker/create-topic.sh /usr/local/bin/create-topic.sh
+RUN chmod +x /usr/local/bin/create-topic.sh
+ENTRYPOINT ["/usr/local/bin/create-topic.sh"]

--- a/README.md
+++ b/README.md
@@ -119,6 +119,22 @@ The application reads Kafka connection details from the environment variables
 `KAFKA_BOOTSTRAP_SERVERS` and `KAFKA_TOPIC` (command line arguments override
 them).
 
+### Creating a Kafka topic locally
+
+Build the helper Docker image and run it with the appropriate environment
+variables to create the topic:
+
+```bash
+docker build -f KafkaTopic.Dockerfile -t kafka-topic-helper .
+docker run --rm \
+  -e KAFKA_BOOTSTRAP_SERVERS=localhost:9092 \
+  -e KAFKA_TOPIC=scan-input \
+  kafka-topic-helper
+```
+
+The image uses the same `KAFKA_BOOTSTRAP_SERVERS` and `KAFKA_TOPIC` variables
+(with optional `KAFKA_PARTITIONS` and `KAFKA_REPLICATION`) to create the topic.
+
 ---
 
 ## 📅 Development Timeline

--- a/docker/create-topic.sh
+++ b/docker/create-topic.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+/opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists \
+  --bootstrap-server "${KAFKA_BOOTSTRAP_SERVERS:-localhost:9092}" \
+  --replication-factor "${KAFKA_REPLICATION:-1}" \
+  --partitions "${KAFKA_PARTITIONS:-1}" \
+  --topic "${KAFKA_TOPIC:-scan-input}"


### PR DESCRIPTION
## Summary
- replace standalone Java helper with Docker-based topic creator
- remove `KafkaTopicCreator` source file
- document Docker usage in README

## Testing
- `sh gradlew test` *(fails: plugin not found)*